### PR TITLE
Feature/simplify encoding gdev 1384

### DIFF
--- a/ekss/api/download/router.py
+++ b/ekss/api/download/router.py
@@ -15,7 +15,6 @@
 """Contains routes and associated data for the download path"""
 
 import base64
-import codecs
 
 from fastapi import APIRouter, Depends, status
 from hexkit.protocols.dao import ResourceNotFoundError
@@ -58,20 +57,16 @@ async def get_header_envelope(
     dao: FileSecretDao = Depends(dao_injector),
 ):
     """Create header envelope for the file secret with given ID encrypted with a given public key"""
-    # Mypy false positives
-    client_pubkey = base64.b64decode(
-        codecs.decode(client_pk, "hex"),
-    )
 
     try:
         header_envelope = await get_envelope(
             secret_id=secret_id,
-            client_pubkey=client_pubkey,
+            client_pubkey=base64.b64decode(client_pk),
             dao=dao,
         )
     except ResourceNotFoundError as error:
         raise exceptions.HttpSecretNotFoundError() from error
 
     return {
-        "content": base64.b64encode(header_envelope).hex(),
+        "content": base64.b64encode(header_envelope).decode("utf-8"),
     }

--- a/ekss/api/download/router.py
+++ b/ekss/api/download/router.py
@@ -61,7 +61,7 @@ async def get_header_envelope(
     try:
         header_envelope = await get_envelope(
             secret_id=secret_id,
-            client_pubkey=base64.b64decode(client_pk),
+            client_pubkey=base64.urlsafe_b64decode(client_pk),
             dao=dao,
         )
     except ResourceNotFoundError as error:

--- a/ekss/api/upload/router.py
+++ b/ekss/api/upload/router.py
@@ -15,7 +15,6 @@
 """Contains routes and associated data for the upload path"""
 
 import base64
-import codecs
 
 from fastapi import APIRouter, Depends, status
 
@@ -63,10 +62,8 @@ async def post_encryption_secrets(
     """Extract file encryption/decryption secret, create secret ID and extract
     file content offset"""
     # Mypy false positives
-    client_pubkey = base64.b64decode(
-        codecs.decode(envelope_query.public_key, "hex"),
-    )
-    file_part = base64.b64decode(codecs.decode(envelope_query.file_part, "hex"))
+    client_pubkey = base64.b64decode(envelope_query.public_key)
+    file_part = base64.b64decode(envelope_query.file_part)
     try:
 
         file_secret, offset = await extract_envelope_content(
@@ -80,7 +77,7 @@ async def post_encryption_secrets(
         raise exceptions.HttpMalformedOrMissingEnvelopeError() from error
     stored_secret = await dao.insert_file_secret(file_secret=file_secret)
     return {
-        "secret": base64.b64encode(file_secret).hex(),
+        "secret": base64.b64encode(file_secret).decode("utf-8"),
         "secret_id": stored_secret.id,
         "offset": offset,
     }

--- a/ekss/core/dao/mongo_db.py
+++ b/ekss/core/dao/mongo_db.py
@@ -63,8 +63,8 @@ class FileSecretDao:
 
     async def insert_file_secret(self, *, file_secret: bytes) -> FileSecretDto:
         """Encode and insert file secret into db"""
-        file_secret = base64.b64encode(file_secret)
-        file_secret_dto = FileSecretCreationDto(file_secret=file_secret)
+        secret = base64.b64encode(file_secret).decode("utf-8")
+        file_secret_dto = FileSecretCreationDto(file_secret=secret)
         dao = await self._get_file_secret_dao()
         response = await dao.insert(file_secret_dto)
         return response

--- a/ekss/core/envelope_encryption.py
+++ b/ekss/core/envelope_encryption.py
@@ -45,7 +45,6 @@ async def create_envelope(*, file_secret: bytes, client_pubkey: bytes) -> bytes:
     Gather file encryption/decryption secret and assemble a crypt4gh envelope using the
     servers private and the clients public key
     """
-
     server_private_key = base64.b64decode(CONFIG.server_private_key.get_secret_value())
     keys = [(0, server_private_key, client_pubkey)]
     header_content = crypt4gh.header.make_packet_data_enc(0, file_secret)

--- a/tests/fixtures/envelope_fixture.py
+++ b/tests/fixtures/envelope_fixture.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import base64
 import os
 from dataclasses import dataclass
 from typing import AsyncGenerator
@@ -49,7 +48,7 @@ async def envelope_fixture(
     Generates an EnvelopeFixture, containing a client public key as well as a secret id
     That secret id corresponds to a random secret created and put into the database
     """
-    secret = base64.b64encode(os.urandom(32))
+    secret = os.urandom(32)
 
     # put secret in database
     stored_secret = await dao_fixture.insert_file_secret(file_secret=secret)

--- a/tests/integration/test_get_endpoint.py
+++ b/tests/integration/test_get_endpoint.py
@@ -15,7 +15,6 @@
 """Checking if GET on /secrets/{secret_id}/envelopes/{client_pk} works correctly"""
 
 import base64
-import codecs
 import io
 
 import crypt4gh.header
@@ -48,11 +47,11 @@ async def test_get_envelope(
 
     app.dependency_overrides[dao_injector] = dao_override
     secret_id = envelope_fixture.secret_id
-    client_pk = base64.b64encode(envelope_fixture.client_pk).hex()
+    client_pk = base64.b64encode(envelope_fixture.client_pk).decode("utf-8")
     response = client.get(url=f"/secrets/{secret_id}/envelopes/{client_pk}")
     assert response.status_code == 200
     body = response.json()
-    content = base64.b64decode(codecs.decode(body["content"], "hex"))
+    content = base64.b64decode(body["content"])
     assert content
     keys = [(0, envelope_fixture.client_sk, None)]
     session_keys, _ = crypt4gh.header.deconstruct(
@@ -76,7 +75,7 @@ async def test_wrong_id(
 
     app.dependency_overrides[dao_injector] = dao_override
     secret_id = "wrong_id"
-    client_pk = base64.b64encode(envelope_fixture.client_pk).hex()
+    client_pk = base64.b64encode(envelope_fixture.client_pk).decode("utf-8")
     response = client.get(url=f"/secrets/{secret_id}/envelopes/{client_pk}")
     assert response.status_code == 404
     body = response.json()

--- a/tests/integration/test_get_endpoint.py
+++ b/tests/integration/test_get_endpoint.py
@@ -47,7 +47,7 @@ async def test_get_envelope(
 
     app.dependency_overrides[dao_injector] = dao_override
     secret_id = envelope_fixture.secret_id
-    client_pk = base64.b64encode(envelope_fixture.client_pk).decode("utf-8")
+    client_pk = base64.urlsafe_b64encode(envelope_fixture.client_pk).decode("utf-8")
     response = client.get(url=f"/secrets/{secret_id}/envelopes/{client_pk}")
     assert response.status_code == 200
     body = response.json()
@@ -75,7 +75,7 @@ async def test_wrong_id(
 
     app.dependency_overrides[dao_injector] = dao_override
     secret_id = "wrong_id"
-    client_pk = base64.b64encode(envelope_fixture.client_pk).decode("utf-8")
+    client_pk = base64.urlsafe_b64encode(envelope_fixture.client_pk).decode("utf-8")
     response = client.get(url=f"/secrets/{secret_id}/envelopes/{client_pk}")
     assert response.status_code == 404
     body = response.json()

--- a/tests/integration/test_post_endpoint.py
+++ b/tests/integration/test_post_endpoint.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Checking if POST on /secrets works correctly"""
 import base64
-import codecs
 import io
 
 import crypt4gh.header
@@ -50,13 +49,15 @@ async def test_post_secrets(
     payload = first_part_fixture.content
 
     request_body = {
-        "public_key": base64.b64encode(first_part_fixture.client_pubkey).hex(),
-        "file_part": base64.b64encode(payload).hex(),
+        "public_key": base64.b64encode(first_part_fixture.client_pubkey).decode(
+            "utf-8"
+        ),
+        "file_part": base64.b64encode(payload).decode("utf-8"),
     }
     response = client.post(url="/secrets", json=request_body)
     assert response.status_code == 200
     body = response.json()
-    secret = base64.b64decode(codecs.decode(body["secret"], "hex"))
+    secret = base64.b64decode(body["secret"])
 
     server_private_key = base64.b64decode(CONFIG.server_private_key.get_secret_value())
     # (method - only 0 supported for now, private_key, public_key)
@@ -84,10 +85,12 @@ async def test_corrupted_header(
     app.dependency_overrides[dao_injector] = dao_override
 
     payload = b"k" + first_part_fixture.content[2:]
-    content = base64.b64encode(payload).hex()
+    content = base64.b64encode(payload).decode("utf-8")
 
     request_body = {
-        "public_key": base64.b64encode(first_part_fixture.client_pubkey).hex(),
+        "public_key": base64.b64encode(first_part_fixture.client_pubkey).decode(
+            "utf-8"
+        ),
         "file_part": content,
     }
 
@@ -111,11 +114,13 @@ async def test_missing_envelope(
     app.dependency_overrides[dao_injector] = dao_override
 
     payload = first_part_fixture.content
-    content = base64.b64encode(payload).hex()
+    content = base64.b64encode(payload).decode("utf-8")
     content = content[124:]
 
     request_body = {
-        "public_key": base64.b64encode(first_part_fixture.client_pubkey).hex(),
+        "public_key": base64.b64encode(first_part_fixture.client_pubkey).decode(
+            "utf-8"
+        ),
         "file_part": content,
     }
 


### PR DESCRIPTION
```
Changed encoding of base64 bytes objects to use utf-8 directly instead of hex representation for conversion to string

Co-authored-by: KerstenBreuer <kersten-breuer@outlook.com>
Co-authored-by: Moritz Hahn <Moritz.Hahn@uni-tuebingen.de>
```