### PR TITLE
Fixed vault.delete_secret

### DIFF
--- a/tests/fixtures/vault.py
+++ b/tests/fixtures/vault.py
@@ -81,6 +81,9 @@ def configure_vault(*, host: str, port: int):
     path "secret/data/ekss/*" {
         capabilities = ["read", "create"]
     }
+    path "secret/metadata/ekss/*" {
+        capabilities = ["delete"]
+    }
     """
 
     # inject policy

--- a/tests/unit/test_vault_interaction.py
+++ b/tests/unit/test_vault_interaction.py
@@ -16,14 +16,21 @@
 
 import os
 
+import pytest
+
+from ekss.adapters.outbound.vault.exceptions import SecretRetrievalError
 from tests.fixtures.vault import vault_fixture  # noqa: F401
 from tests.fixtures.vault import VaultFixture
 
 
 def test_connection(vault_fixture: VaultFixture):  # noqa: F811
-    """Test if container is up and reachable"""
+    """Test if container is up and reachable and commands are working"""
 
     secret = os.urandom(32)
     secret_id = vault_fixture.adapter.store_secret(secret=secret)
     stored_secret = vault_fixture.adapter.get_secret(key=secret_id)
     assert secret == stored_secret
+
+    vault_fixture.adapter.delete_secret(key=secret_id)
+    with pytest.raises(SecretRetrievalError):
+        vault_fixture.adapter.get_secret(key=secret_id)

--- a/tests/unit/test_vault_interaction.py
+++ b/tests/unit/test_vault_interaction.py
@@ -26,11 +26,21 @@ from tests.fixtures.vault import VaultFixture
 def test_connection(vault_fixture: VaultFixture):  # noqa: F811
     """Test if container is up and reachable and commands are working"""
 
+    # populate
     secret = os.urandom(32)
+    secret2 = os.urandom(32)
     secret_id = vault_fixture.adapter.store_secret(secret=secret)
+    secret2_id = vault_fixture.adapter.store_secret(secret=secret2)
+
+    # test retrieval
     stored_secret = vault_fixture.adapter.get_secret(key=secret_id)
     assert secret == stored_secret
 
+    # test deletion
     vault_fixture.adapter.delete_secret(key=secret_id)
     with pytest.raises(SecretRetrievalError):
         vault_fixture.adapter.get_secret(key=secret_id)
+
+    # test deletion only affected correct path
+    stored_secret2 = vault_fixture.adapter.get_secret(key=secret2_id)
+    assert secret2 == stored_secret2


### PR DESCRIPTION
```
Made v2 explicit instead of setting it in constructor
Replaced v1 delete method with v2 one nuking all key info for path
Added test for correct deletion
```

`client.secrets.kv.v2.delete_metadata_and_all_versions(path=path)` should remove all data and metadata for a secret under the given path for all secret versions.
This change necessitates an update for the vault policies in the testbed and deployment to allow the ekss to delete metadata for the keys it stored (see the change in the fixture for comparison).